### PR TITLE
Fixed 'mongo not found' error and replicas in docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,7 +163,7 @@ services:
         aliases:
           - mongos-router0
     environment:
-      - SHARD_LIST=shard0/shard0-replica0:27017,shard0-replica0:27017,shard0-replica0:27017;shard1/shard1-replica0:27017,shard1-replica0:27017,shard1-replica0:27017
+      - SHARD_LIST=shard0/shard0-replica0:27017,shard0-replica1:27017,shard0-replica2:27017;shard1/shard1-replica0:27017,shard1-replica1:27017,shard1-replica2:27017
     expose:
       - "27017"
     ports:

--- a/mongod/mongod-runextra.sh
+++ b/mongod/mongod-runextra.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
 # Wait until local MongoDB instance is up and running
-until /usr/bin/mongo --port 27017 --quiet --eval 'db.getMongo()'; do
+until mongosh --port 27017 --quiet --eval 'db.getMongo()'; do
     sleep 1
 done
 
 # Configure a MongoDB replica set (doesn't matter if each container attempts
 # to run same action, first one wins, other attempts will then be ignored)
-/usr/bin/mongo --port 27017 <<EOF
+mongosh --port 27017 <<EOF
     rs.initiate({_id: "${REPSET_NAME}", members: [
         {_id: 0, host: "${REPSET_NAME}-replica0:27017"},
         {_id: 1, host: "${REPSET_NAME}-replica1:27017"},

--- a/mongos/mongos-runextra.sh
+++ b/mongos/mongos-runextra.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Wait until mongos can return a connection
-until mongo --quiet --eval 'db.getMongo()'; do
+until mongosh --quiet --eval 'db.getMongo()'; do
     sleep 1
 done
 
@@ -12,7 +12,7 @@ IFS=';' read -r -a array <<< "$SHARD_LIST"
 
 # Add each shard definition to the cluster
 for shard in "${array[@]}"; do  
-    /usr/bin/mongo --port 27017 <<EOF
+    mongosh --port 27017 <<EOF
         sh.addShard("${shard}");
 EOF
 done


### PR DESCRIPTION
I think in newer versions of the mongo image the mongo command doesn't exist anymore, it got replaced by mongosh.